### PR TITLE
[BUGFIX] Catch exception for sites that do not include the typoscript setup

### DIFF
--- a/Classes/Hooks/FootnotesHook.php
+++ b/Classes/Hooks/FootnotesHook.php
@@ -40,7 +40,10 @@ class FootnotesHook
      */
     protected $objectManager;
 
-    protected $fonfig = null;
+    /**
+     * @var array
+     */
+    protected $config = [];
 
 
     public function __construct()
@@ -53,7 +56,7 @@ class FootnotesHook
         $tsService = GeneralUtility::makeInstance(TypoScriptService::class);
         $fullTs = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 
-        $this->config = $tsService->convertTypoScriptArrayToPlainArray($fullTs['plugin.']['tx_t3footnotes.']);
+        $this->config = $tsService->convertTypoScriptArrayToPlainArray($fullTs['plugin.']['tx_t3footnotes.'] ?? []);
     }
 
     /**
@@ -62,6 +65,10 @@ class FootnotesHook
      */
     public function generateFootnotes($params, $pObj)
     {
+        if (empty($this->config)) {
+            return;
+        }
+
         // init vars
         $patternFootnoteAnchors = '/<sup[ ]+class="t3foonote">(?:.(?!\<\/sup\>))*.<\/sup>/i';
         $patternFootnoteAnchorDataAttr = '/(<span[ ]+class="t3foonotes-anchor-data".*?>)((?:.(?!\<\/span\>))*.)(<\/span>)/i';


### PR DESCRIPTION
We have a multi-site installation where not all sites include the TypoScript Setup of this extension as they don't use footnotes. For these sites `plugin.tx_t3footnotes` is not defined and this exception is thrown.

`Argument 1 passed to TYPO3\CMS\Core\TypoScript\TypoScriptService::convertTypoScriptArrayToPlainArray() must be of the type array, null given, called in /var/www/html/private/typo3conf/ext/t3footnotes/Classes/Hooks/FootnotesHook.php on line 59`

This PR catches that and also exits early in case the configuration is empty.